### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/setup-node.yml
+++ b/.github/workflows/setup-node.yml
@@ -1,5 +1,8 @@
 name: Setup Node.js Environment
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/UnicornXOSW2.1.0/security/code-scanning/1](https://github.com/billlzzz10/UnicornXOSW2.1.0/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not require write access to repository contents or other resources, we can set the permissions to `contents: read`. This limits the `GITHUB_TOKEN` to read-only access, adhering to the principle of least privilege. The `permissions` block should be added at the root level of the workflow, so it applies to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
